### PR TITLE
Feat/#27 토큰 재발급 api 구현

### DIFF
--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -2,13 +2,14 @@ package friendy.community.domain.auth.controller;
 
 import friendy.community.domain.auth.dto.request.LoginRequest;
 import friendy.community.domain.auth.dto.response.TokenResponse;
+import friendy.community.domain.auth.jwt.JwtTokenExtractor;
 import friendy.community.domain.auth.service.AuthService;
-import org.springframework.web.bind.annotation.RequestBody;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements SpringDocAuthController{
 
     private final AuthService authService;
+    private final JwtTokenExtractor jwtTokenExtractor;
 
     @PostMapping("/login")
     public ResponseEntity<Void> login(
@@ -31,9 +33,10 @@ public class AuthController implements SpringDocAuthController{
 
     @PostMapping("/token/reissue")
     public ResponseEntity<Void> reissueToken(
-            @RequestHeader("Authorization-Refresh") String refreshToken
+            HttpServletRequest httpServletRequest
     ) {
-        final TokenResponse response = authService.reissueToken(refreshToken.replace("Bearer ", ""));
+        final String refreshToken = jwtTokenExtractor.extractRefreshToken(httpServletRequest);
+        final TokenResponse response = authService.reissueToken(refreshToken);
 
         return ResponseEntity.ok()
                 .header("Authorization", "Bearer " + response.accessToken())

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package friendy.community.domain.auth.controller;
 
 import friendy.community.domain.auth.dto.request.LoginRequest;
-import friendy.community.domain.auth.dto.response.LoginResponse;
+import friendy.community.domain.auth.dto.response.TokenResponse;
 import friendy.community.domain.auth.service.AuthService;
 import org.springframework.web.bind.annotation.RequestBody;
 import jakarta.validation.Valid;
@@ -20,7 +20,13 @@ public class AuthController implements SpringDocAuthController{
     public ResponseEntity<Void> login(
             @Valid @RequestBody LoginRequest loginRequest
     ) {
-        final LoginResponse response = authService.login(loginRequest);
+        final TokenResponse response = authService.login(loginRequest);
+
+        return ResponseEntity.ok()
+                .header("Authorization", "Bearer " + response.accessToken())
+                .header("Authorization-Refresh", "Bearer " + response.refreshToken())
+                .build();
+    }
 
         return ResponseEntity.ok()
                 .header("Authorization", "Bearer " + response.accessToken())

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +28,12 @@ public class AuthController implements SpringDocAuthController{
                 .header("Authorization-Refresh", "Bearer " + response.refreshToken())
                 .build();
     }
+
+    @PostMapping("/token/reissue")
+    public ResponseEntity<Void> reissueToken(
+            @RequestHeader("Authorization-Refresh") String refreshToken
+    ) {
+        final TokenResponse response = authService.reissueToken(refreshToken.replace("Bearer ", ""));
 
         return ResponseEntity.ok()
                 .header("Authorization", "Bearer " + response.accessToken())

--- a/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "인증 및 인가 API", description = "인증 및 인가 API")
 public interface SpringDocAuthController {
@@ -33,5 +34,19 @@ public interface SpringDocAuthController {
             @ErrorCase(description = "비밀번호 불일치", exampleMessage = "로그인에 실패하였습니다. 비밀번호를 확인해주세요."),
     })
     ResponseEntity<Void> login(LoginRequest request);
+
+    @Operation(summary = "토큰 재발급")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+            headers = {
+                    @Header(name = "Authorization", description = "새로운 액세스 토큰", required = true, schema = @Schema(type = "string")),
+                    @Header(name = "Authorization-Refresh", description = "새로운 리프레시 토큰", required = true, schema = @Schema(type = "string"))
+            }
+    )
+    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/token/reissue", errorCases = {
+            @ErrorCase(description = "잘못된 리프레시 토큰", exampleMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : {token}"),
+            @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "리프레시 토큰이 만료되었습니다."),
+            @ErrorCase(description = "리프레시 토큰에 이메일 클레임 없음", exampleMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : {token}")
+    })
+    ResponseEntity<Void> reissueToken(@RequestHeader("Authorization-Refresh") String refreshToken);
 
 }

--- a/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
@@ -7,10 +7,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "인증 및 인가 API", description = "인증 및 인가 API")
 public interface SpringDocAuthController {
@@ -35,7 +36,13 @@ public interface SpringDocAuthController {
     })
     ResponseEntity<Void> login(LoginRequest request);
 
-    @Operation(summary = "토큰 재발급")
+    @Operation(
+            summary = "토큰 재발급",
+            security = {
+                    @SecurityRequirement(name = "bearerAuth"),
+                    @SecurityRequirement(name = "refreshAuth")
+            }
+    )
     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
             headers = {
                     @Header(name = "Authorization", description = "새로운 액세스 토큰", required = true, schema = @Schema(type = "string")),
@@ -47,6 +54,6 @@ public interface SpringDocAuthController {
             @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "리프레시 토큰이 만료되었습니다."),
             @ErrorCase(description = "리프레시 토큰에 이메일 클레임 없음", exampleMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : {token}")
     })
-    ResponseEntity<Void> reissueToken(@RequestHeader("Authorization-Refresh") String refreshToken);
+    ResponseEntity<Void> reissueToken(HttpServletRequest httpServletRequest);
 
 }

--- a/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
@@ -51,7 +51,7 @@ public interface SpringDocAuthController {
     )
     @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/token/reissue", errorCases = {
             @ErrorCase(description = "잘못된 리프레시 토큰", exampleMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : {token}"),
-            @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "리프레시 토큰이 만료되었습니다."),
+            @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : {token}"),
             @ErrorCase(description = "리프레시 토큰에 이메일 클레임 없음", exampleMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : {token}")
     })
     ResponseEntity<Void> reissueToken(HttpServletRequest httpServletRequest);

--- a/src/main/java/friendy/community/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/friendy/community/domain/auth/dto/response/TokenResponse.java
@@ -2,13 +2,13 @@ package friendy.community.domain.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record LoginResponse(
+public record TokenResponse(
         @Schema(description = "액세스 토큰", example = "header.payload.signature")
         String accessToken,
         @Schema(description = "리프레쉬 토큰", example = "header.payload.signature")
         String refreshToken
 ) {
-    public static LoginResponse of(final String accessToken, final String refreshToken) {
-        return new LoginResponse(accessToken, refreshToken);
+    public static TokenResponse of(final String accessToken, final String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -83,7 +83,8 @@ public class JwtTokenProvider {
             final String logMessage = "인증 실패(잘못된 액세스 토큰) - 토큰 : " + token;
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         } catch (ExpiredJwtException e) {
-            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, "액세스 토큰이 만료되었습니다.");
+            final String logMessage = "인증 실패(만료된 액세스 토큰) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         }
     }
 
@@ -94,7 +95,8 @@ public class JwtTokenProvider {
             final String logMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token;
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         } catch (ExpiredJwtException e) {
-            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, "리프레시 토큰이 만료되었습니다.");
+            final String logMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         }
     }
 

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -52,6 +52,30 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    public String extractEmailFromAccessToken(final String token) {
+        validateAccessToken(token);
+        final Jws<Claims> claimsJws = getAccessTokenParser().parseClaimsJws(token);
+        final String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
+        if (extractedEmail == null) {
+            final String logMessage = "인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
+        }
+
+        return extractedEmail;
+    }
+
+    public String extractEmailFromRefreshToken(final String token) {
+        validateRefreshToken(token);
+        final Jws<Claims> claimsJws = getRefreshTokenParser().parseClaimsJws(token);
+        final String extractedEmail = claimsJws.getBody().get(EMAIL_KEY, String.class);
+        if (extractedEmail == null) {
+            final String logMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
+        }
+
+        return extractedEmail;
+    }
+
     public void validateAccessToken(final String token) {
         try {
             final Claims claims = getAccessTokenParser().parseClaimsJws(token).getBody();

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -29,6 +29,14 @@ public class AuthService {
 
         return TokenResponse.of(accessToken, refreshToken);
     }
+
+    public TokenResponse reissueToken(final String refreshToken) {
+        final String extractedEmail = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
+        final Member member = getMemberByEmail(extractedEmail);
+        final String newAccessToken = jwtTokenProvider.generateAccessToken(member.getEmail());
+        final String newRefreshToken = jwtTokenProvider.generateRefreshToken(member.getEmail());
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
     }
 
     private Member getVerifiedMember(String email, String password) {

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package friendy.community.domain.auth.service;
 
 import friendy.community.domain.auth.dto.request.LoginRequest;
-import friendy.community.domain.auth.dto.response.LoginResponse;
+import friendy.community.domain.auth.dto.response.TokenResponse;
 import friendy.community.domain.auth.jwt.JwtTokenProvider;
 import friendy.community.domain.member.encryption.PasswordEncryptor;
 import friendy.community.domain.member.model.Member;
@@ -22,12 +22,13 @@ public class AuthService {
     private final PasswordEncryptor passwordEncryptor;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public LoginResponse login(final LoginRequest request) {
+    public TokenResponse login(final LoginRequest request) {
         final Member member = getVerifiedMember(request.email(), request.password());
         final String accessToken = jwtTokenProvider.generateAccessToken(request.email());
         final String refreshToken = jwtTokenProvider.generateRefreshToken(request.email());
-        
-        return LoginResponse.of(accessToken, refreshToken);
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
     }
 
     private Member getVerifiedMember(String email, String password) {

--- a/src/main/java/friendy/community/global/swagger/SwaggerConfig.java
+++ b/src/main/java/friendy/community/global/swagger/SwaggerConfig.java
@@ -1,5 +1,10 @@
 package friendy.community.global.swagger;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
@@ -27,12 +32,45 @@ public class SwaggerConfig {
         server.setDescription(SERVER_DESCRIPTION);
 
         final Info info = new Info()
-            .title(DOCS_TITLE)
-            .version(DOCS_VERSION)
-            .description(DOCS_DESCRIPTION);
+                .title(DOCS_TITLE)
+                .version(DOCS_VERSION)
+                .description(DOCS_DESCRIPTION);
 
         return new OpenAPI()
-            .info(info)
-            .servers(List.of(server));
+                .info(info)
+                .servers(List.of(server))
+                .components(generateComponents())
+                .security(List.of(generateSecurityRequirement()));
     }
+
+    private Components generateComponents() {
+        return new Components()
+                .addSecuritySchemes("bearerAuth", generateAccessTokenScheme())
+                .addSecuritySchemes("refreshAuth", generateRefreshTokenScheme());
+    }
+
+    private SecurityRequirement generateSecurityRequirement() {
+        return new SecurityRequirement()
+                .addList("bearerAuth")
+                .addList("refreshAuth");
+    }
+
+    private SecurityScheme generateAccessTokenScheme() {
+        return new SecurityScheme()
+                .type(Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(In.HEADER)
+                .name("Authorization")
+                .description("Bearer Access Token");
+    }
+
+    private SecurityScheme generateRefreshTokenScheme() {
+        return new SecurityScheme()
+                .type(Type.APIKEY)
+                .in(In.HEADER)
+                .name("Authorization-Refresh")
+                .description("Refresh Token");
+    }
+
 }

--- a/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
@@ -2,7 +2,7 @@ package friendy.community.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import friendy.community.domain.auth.dto.request.LoginRequest;
-import friendy.community.domain.auth.dto.response.LoginResponse;
+import friendy.community.domain.auth.dto.response.TokenResponse;
 import friendy.community.domain.auth.service.AuthService;
 import friendy.community.global.exception.ErrorCode;
 import friendy.community.global.exception.FriendyException;
@@ -44,7 +44,7 @@ class AuthControllerTest {
     void loginSuccessfullyReturnsTokensInHeaders() throws Exception {
         // Given
         LoginRequest loginRequest = new LoginRequest("example@friendy.com", "password123!");
-        LoginResponse loginResponse = LoginResponse.of("accessToken", "refreshToken");
+        TokenResponse loginResponse = TokenResponse.of("accessToken", "refreshToken");
 
         when(authService.login(any(LoginRequest.class))).thenReturn(loginResponse);
 

--- a/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
@@ -240,7 +240,7 @@ class AuthControllerTest {
                 .thenReturn("expiredRefreshToken");
 
         when(authService.reissueToken("expiredRefreshToken"))
-                .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_USER, "리프레시 토큰이 만료되었습니다."));
+                .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_USER, "인증 실패(만료된 리프레시 토큰) - 토큰 : expiredRefreshToken"));
 
         // When & Then
         mockMvc.perform(post("/token/reissue")
@@ -248,7 +248,7 @@ class AuthControllerTest {
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(result -> assertThat(result.getResolvedException().getMessage())
-                        .contains("리프레시 토큰이 만료되었습니다."));
+                        .contains("인증 실패(만료된 리프레시 토큰) - 토큰 : expiredRefreshToken"));
     }
 
     @Test

--- a/src/test/java/friendy/community/domain/auth/fixtures/TokenFixtures.java
+++ b/src/test/java/friendy/community/domain/auth/fixtures/TokenFixtures.java
@@ -2,6 +2,11 @@ package friendy.community.domain.auth.fixtures;
 
 public class TokenFixtures {
 
+    /**
+     * CORRECT_REFRESH_TOKEN : 만료 기한 - 2123년 10월 30일
+     */
+    public static final String CORRECT_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImV4YW1wbGVAZnJpZW5keS5jb20iLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6NDg1NDI3ODQwMH0.I5Y8zaMf6ys1X3ESNzVK3HzH7mJFquPwiyAnmiH4RQg";
+
     public static final String MALFORMED_JWT_TOKEN = "aabbcc";
 
     public static final String EXPIRED_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImV4YW1wbGVAZnJpZW5keS5jb20iLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDEwMH0.mqOL2LPVIqTlrjqAWElM5XsJMgTjxWsEpOkr0atIdKs";

--- a/src/test/java/friendy/community/domain/auth/fixtures/TokenFixtures.java
+++ b/src/test/java/friendy/community/domain/auth/fixtures/TokenFixtures.java
@@ -6,5 +6,10 @@ public class TokenFixtures {
 
     public static final String EXPIRED_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImV4YW1wbGVAZnJpZW5keS5jb20iLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDEwMH0.mqOL2LPVIqTlrjqAWElM5XsJMgTjxWsEpOkr0atIdKs";
 
+    /**
+     * MISSING_CLAIM_TOKEN : 만료 기한 - 2123년 10월 30일
+     */
+    public static final String MISSING_CLAIM_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDAwMDAwMDAsImV4cCI6NDg1NDI3ODQwMH0.65lNI_07FgETBnasvHCzxc1RDfLSoDBJr0Vebocu2gI";
+
 }
 

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -64,7 +64,7 @@ class JwtTokenProviderTest {
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(expiredAccessToken))
                 .isInstanceOf(FriendyException.class)
-                .hasMessageContaining("액세스 토큰이 만료되었습니다.");
+                .hasMessageContaining("인증 실패(만료된 액세스 토큰) - 토큰 : " + expiredAccessToken);
     }
 
     @Test
@@ -127,7 +127,7 @@ class JwtTokenProviderTest {
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(expiredRefreshToken))
                 .isInstanceOf(FriendyException.class)
-                .hasMessageContaining("리프레시 토큰이 만료되었습니다.");
+                .hasMessageContaining("인증 실패(만료된 리프레시 토큰) - 토큰 : " + expiredRefreshToken);
     }
 
     @Test

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -30,38 +30,53 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("엑세스 토큰 검증에 성공한다")
-    void validateAccessTokenSuccessfully() {
+    @DisplayName("엑세스 토큰에서 이메일을 추출한다")
+    void extractEmailFromAccessTokenSuccessfully() {
         // given
         String email = "example@friendy.com";
         String accessToken = jwtTokenProvider.generateAccessToken(email);
 
-        // when & then
-        jwtTokenProvider.validateAccessToken(accessToken);
+        // when
+        String extractedEmail = jwtTokenProvider.extractEmailFromAccessToken(accessToken);
+
+        // then
+        assertThat(extractedEmail).isEqualTo(email);
     }
 
     @Test
-    @DisplayName("잘못된 형식의 엑세스 토큰이 검증 시 예외를 발생시킨다")
-    void throwExceptionForMalformedAccessToken() {
+    @DisplayName("잘못된 형식의 엑세스 토큰에서 이메일 추출 시 예외를 발생시킨다")
+    void throwExceptionForMalformedAccessTokenEmailExtraction() {
         // given
         String malFormedJwtToken = MALFORMED_JWT_TOKEN;
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateAccessToken(malFormedJwtToken))
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(malFormedJwtToken))
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("인증 실패(잘못된 액세스 토큰) - 토큰 : " + malFormedJwtToken);
     }
 
     @Test
-    @DisplayName("만료된 엑세스 토큰이 검증 시 예외를 발생시킨다")
-    void throwExceptionForExpiredAccessToken() {
+    @DisplayName("만료된 엑세스 토큰에서 이메일 추출 시 예외를 발생시킨다")
+    void throwExceptionForExpiredAccessTokenEmailExtraction() {
         // given
         String expiredAccessToken = EXPIRED_TOKEN;
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateAccessToken(expiredAccessToken))
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(expiredAccessToken))
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("액세스 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰에 이메일 클레임이 누락된 경우 예외를 발생시킨다")
+    void throwExceptionForMissingEmailClaimInAccessToken() {
+        // given
+        String tokenWithoutEmailClaim = MISSING_CLAIM_TOKEN;
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromAccessToken(tokenWithoutEmailClaim))
+                .isInstanceOf(FriendyException.class)
+                .hasMessageContaining("인증 실패(JWT 액세스 토큰 Payload 이메일 누락) - 토큰 : " + tokenWithoutEmailClaim);
     }
 
     @Test
@@ -78,37 +93,52 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("리프레시 토큰 검증에 성공한다")
-    void validateRefreshTokenSuccessfully() {
+    @DisplayName("리프레시 토큰에서 이메일을 추출한다")
+    void extractEmailFromRefreshTokenSuccessfully() {
         // given
         String email = "example@friendy.com";
         String refreshToken = jwtTokenProvider.generateRefreshToken(email);
 
-        // when & then
-        jwtTokenProvider.validateRefreshToken(refreshToken);
+        // when
+        String extractedEmail = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
+
+        // then
+        assertThat(extractedEmail).isEqualTo(email);
     }
 
     @Test
-    @DisplayName("잘못된 형식의 리프레시 토큰이 검증 시 예외를 발생시킨다")
-    void throwExceptionForMalformedRefreshToken() {
+    @DisplayName("잘못된 형식의 리프레시 토큰에서 이메일 추출 시 예외를 발생시킨다")
+    void throwExceptionForMalformedRefreshTokenEmailExtraction() {
         // given
         String malFormedJwtToken = MALFORMED_JWT_TOKEN;
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateRefreshToken(malFormedJwtToken))
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(malFormedJwtToken))
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("인증 실패(잘못된 리프레시 토큰) - 토큰 : " + malFormedJwtToken);
     }
 
     @Test
-    @DisplayName("만료된 리프레시 토큰이 검증 시 예외를 발생시킨다")
-    void throwExceptionForExpiredRefreshToken() {
+    @DisplayName("만료된 리프레시 토큰에서 이메일 추출 시 예외를 발생시킨다")
+    void throwExceptionForExpiredRefreshTokenEmailExtraction() {
         // given
         String expiredRefreshToken = EXPIRED_TOKEN;
 
         // when & then
-        assertThatThrownBy(() -> jwtTokenProvider.validateRefreshToken(expiredRefreshToken))
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(expiredRefreshToken))
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("리프레시 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰에 이메일 클레임이 누락된 경우 예외를 발생시킨다")
+    void throwExceptionForMissingEmailClaimInRefreshToken() {
+        // given
+        String tokenWithoutEmailClaim = MISSING_CLAIM_TOKEN;
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(tokenWithoutEmailClaim))
+                .isInstanceOf(FriendyException.class)
+                .hasMessageContaining("인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + tokenWithoutEmailClaim);
     }
 }

--- a/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package friendy.community.domain.auth.service;
 
 import friendy.community.domain.auth.dto.request.LoginRequest;
-import friendy.community.domain.auth.dto.response.LoginResponse;
+import friendy.community.domain.auth.dto.response.TokenResponse;
 import friendy.community.domain.member.fixture.MemberFixture;
 import friendy.community.domain.member.model.Member;
 import friendy.community.domain.member.repository.MemberRepository;
@@ -35,7 +35,7 @@ class AuthServiceTest {
         LoginRequest loginRequest = new LoginRequest(savedMember.getEmail(), MemberFixture.getFixturePlainPassword());
 
         // When
-        LoginResponse response = authService.login(loginRequest);
+        TokenResponse response = authService.login(loginRequest);
 
         // Then
         assertThat(response.accessToken()).isNotNull();

--- a/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
+import static friendy.community.domain.auth.fixtures.TokenFixtures.CORRECT_REFRESH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -65,6 +66,21 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.login(loginRequest))
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("로그인에 실패하였습니다. 비밀번호를 확인해주세요.");
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 시 새로운 액세스 토큰과 리프레시 토큰이 반환된다.")
+    void reissueTokenSuccessfullyReturnsNewTokens() {
+        // Given
+        Member savedMember = memberRepository.save(MemberFixture.memberFixture());
+        String refreshToken = CORRECT_REFRESH_TOKEN;
+
+        // When
+        TokenResponse response = authService.reissueToken(refreshToken);
+
+        // Then
+        assertThat(response.accessToken()).isNotNull();
+        assertThat(response.refreshToken()).isNotNull();
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #27 

<br/>

## 🔎 작업 내용

- 토큰 재발급 api
- 스웨거에 토큰 입력란 추가
- 토큰 헤더로 받는걸로 수정

AuthService 리팩토링 필요해보입니다 ( 멤버 받아서 액세스, 리프레시 토큰 생성 jwtTokenProvider로 이동 가능해보임 )
<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?