### PR TITLE
Feat/#32 이메일 인증 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,8 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script_stop: true
           script: |
+            export REDIS_HOST=${{ secrets.REDIS_HOST }}
+            export MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }}
             export SERVER_URL=${{ secrets.SERVER_URL }}
             export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             export JWT_ACCESS_EXPIRATION=${{ secrets.JWT_ACCESS_EXPIRATION }}

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/friendy/community/domain/email/controller/EmailController.java
+++ b/src/main/java/friendy/community/domain/email/controller/EmailController.java
@@ -24,4 +24,10 @@ public class EmailController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/verify-code")
+    public ResponseEntity<Void> verifyAuthCode(@Valid @RequestBody VerifyCodeRequest request) {
+        emailService.verifyAuthCode(request);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/friendy/community/domain/email/controller/EmailController.java
+++ b/src/main/java/friendy/community/domain/email/controller/EmailController.java
@@ -1,0 +1,27 @@
+package friendy.community.domain.email.controller;
+
+import friendy.community.domain.email.dto.request.EmailRequest;
+import friendy.community.domain.email.dto.request.VerifyCodeRequest;
+import friendy.community.domain.email.service.EmailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/send-code")
+    public ResponseEntity<Void> sendAuthenticatedEmail(@Valid @RequestBody EmailRequest request) {
+        emailService.sendAuthenticatedEmail(request);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/friendy/community/domain/email/controller/EmailController.java
+++ b/src/main/java/friendy/community/domain/email/controller/EmailController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/email")
 @RequiredArgsConstructor
-public class EmailController {
+public class EmailController implements SpringDocEmailController{
 
     private final EmailService emailService;
 

--- a/src/main/java/friendy/community/domain/email/controller/SpringDocEmailController.java
+++ b/src/main/java/friendy/community/domain/email/controller/SpringDocEmailController.java
@@ -1,0 +1,31 @@
+package friendy.community.domain.email.controller;
+
+import friendy.community.domain.email.dto.request.EmailRequest;
+import friendy.community.domain.email.dto.request.VerifyCodeRequest;
+import friendy.community.global.swagger.error.ApiErrorResponse;
+import friendy.community.global.swagger.error.ErrorCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "사용자 검증 API", description = "사용자 검증 API")
+public interface SpringDocEmailController {
+
+    @Operation(summary = "이메일 인증코드 전송")
+    @ApiResponse(responseCode = "200", description = "인증코드 전송 성공")
+    @ApiErrorResponse(status = HttpStatus.INTERNAL_SERVER_ERROR, instance = "/send-code", errorCases = {
+            @ErrorCase(description = "인증번호 전송 실패", exampleMessage = "이메일 전송에 실패했습니다."),
+    })
+    ResponseEntity<Void> sendAuthenticatedEmail(EmailRequest request);
+
+    @Operation(summary = "이메일 인증코드 검증")
+    @ApiResponse(responseCode = "200", description = "인증코드 검증 성공")
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/verify-code", errorCases = {
+            @ErrorCase(description = "인증번호 없음", exampleMessage = "인증번호가 존재하지 않습니다."),
+            @ErrorCase(description = "인증번호 불일치", exampleMessage = "인증번호가 일치하지 않습니다."),
+    })
+    ResponseEntity<Void> verifyAuthCode(VerifyCodeRequest request);
+
+}

--- a/src/main/java/friendy/community/domain/email/dto/request/EmailRequest.java
+++ b/src/main/java/friendy/community/domain/email/dto/request/EmailRequest.java
@@ -1,0 +1,16 @@
+package friendy.community.domain.email.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 인증코드 전송")
+public record EmailRequest(
+
+        @Schema(description = "이메일", example = "example@friendy.com")
+        @NotBlank(message = "이메일이 입력되지 않았습니다.")
+        @Email(message = "이메일 형식으로 입력해주세요.")
+        String email
+
+) {
+}

--- a/src/main/java/friendy/community/domain/email/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/friendy/community/domain/email/dto/request/VerifyCodeRequest.java
@@ -1,0 +1,20 @@
+package friendy.community.domain.email.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "이메일 인증코드 검증")
+public record VerifyCodeRequest(
+
+        @Schema(description = "이메일 주소", example = "example@friendy.com")
+        @NotBlank(message = "이메일이 입력되지 않았습니다.")
+        @Email(message = "유효한 이메일 주소를 입력해주세요.")
+        String email,
+
+        @Schema(description = "인증 코드", example = "123456")
+        @NotBlank(message = "인증 코드가 입력되지 않았습니다.")
+        String authCode
+
+) {
+}

--- a/src/main/java/friendy/community/domain/email/service/EmailService.java
+++ b/src/main/java/friendy/community/domain/email/service/EmailService.java
@@ -28,8 +28,8 @@ public class EmailService {
 
     public void sendAuthenticatedEmail(final EmailRequest request) {
         try {
-            final String code = generateAndSaveAuthCode(request.email());
-            final MimeMessage message = createEmailMessage(request.email(), code);
+            final String authCode = generateAndSaveAuthCode(request.email());
+            final MimeMessage message = createEmailMessage(request.email(), authCode);
             mailSender.send(message);
         } catch (MessagingException e) {
             throw new FriendyException(ErrorCode.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
@@ -49,17 +49,17 @@ public class EmailService {
     }
 
     private String generateAndSaveAuthCode(final String email) {
-        final String code = generateAuthCode();
-        saveAuthCode(email, code);
-        return code;
+        final String authCode = generateAuthCode();
+        saveAuthCode(email, authCode);
+        return authCode;
     }
 
-    private MimeMessage createEmailMessage(final String toEmail, final String code) throws MessagingException {
+    private MimeMessage createEmailMessage(final String toEmail, final String authCode) throws MessagingException {
         final MimeMessage message = mailSender.createMimeMessage();
         final MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
         helper.setTo(toEmail);
         helper.setSubject("Friendy Community 이메일 인증 코드");
-        helper.setText(getEmailContent(code), true);
+        helper.setText(getEmailContent(authCode), true);
         return message;
     }
 
@@ -69,14 +69,14 @@ public class EmailService {
         return String.format("%06d", random.nextInt(maxRange));
     }
 
-    private void saveAuthCode(final String email, final String code) {
-        redisTemplate.opsForValue().set(email, code, CODE_EXPIRE_MILLIS, TimeUnit.MILLISECONDS);
+    private void saveAuthCode(final String email, final String authCode) {
+        redisTemplate.opsForValue().set(email, authCode, CODE_EXPIRE_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     private String getEmailContent(final String authCode) {
         final Context context = new Context();
         context.setVariable("authCode", authCode);
-        return templateEngine.process("auth-email", context);
+        return templateEngine.process("email", context);
     }
 
 }

--- a/src/main/java/friendy/community/domain/email/service/EmailService.java
+++ b/src/main/java/friendy/community/domain/email/service/EmailService.java
@@ -36,6 +36,18 @@ public class EmailService {
         }
     }
 
+    public void verifyAuthCode(final VerifyCodeRequest request) {
+        final String savedCode = redisTemplate.opsForValue().get(request.email());
+
+        if (savedCode == null) {
+            throw new FriendyException(ErrorCode.INVALID_REQUEST, "인증번호가 존재하지 않습니다.");
+        }
+
+        if (!savedCode.equals(request.authCode())) {
+            throw new FriendyException(ErrorCode.INVALID_REQUEST, "인증번호가 일치하지 않습니다.");
+        }
+    }
+
     private String generateAndSaveAuthCode(final String email) {
         final String code = generateAuthCode();
         saveAuthCode(email, code);

--- a/src/main/java/friendy/community/domain/email/service/EmailService.java
+++ b/src/main/java/friendy/community/domain/email/service/EmailService.java
@@ -1,0 +1,70 @@
+package friendy.community.domain.email.service;
+
+import friendy.community.domain.email.dto.request.EmailRequest;
+import friendy.community.domain.email.dto.request.VerifyCodeRequest;
+import friendy.community.global.exception.ErrorCode;
+import friendy.community.global.exception.FriendyException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+    private static final long CODE_EXPIRE_MILLIS = 300000;  // 5분
+
+    public void sendAuthenticatedEmail(final EmailRequest request) {
+        try {
+            final String code = generateAndSaveAuthCode(request.email());
+            final MimeMessage message = createEmailMessage(request.email(), code);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new FriendyException(ErrorCode.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
+        }
+    }
+
+    private String generateAndSaveAuthCode(final String email) {
+        final String code = generateAuthCode();
+        saveAuthCode(email, code);
+        return code;
+    }
+
+    private MimeMessage createEmailMessage(final String toEmail, final String code) throws MessagingException {
+        final MimeMessage message = mailSender.createMimeMessage();
+        final MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+        helper.setTo(toEmail);
+        helper.setSubject("Friendy Community 이메일 인증 코드");
+        helper.setText(getEmailContent(code), true);
+        return message;
+    }
+
+    private String generateAuthCode() {
+        final int maxRange = 1000000;
+        final Random random = new Random();
+        return String.format("%06d", random.nextInt(maxRange));
+    }
+
+    private void saveAuthCode(final String email, final String code) {
+        redisTemplate.opsForValue().set(email, code, CODE_EXPIRE_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    private String getEmailContent(final String authCode) {
+        final Context context = new Context();
+        context.setVariable("authCode", authCode);
+        return templateEngine.process("auth-email", context);
+    }
+
+}

--- a/src/main/java/friendy/community/global/config/RedisConfig.java
+++ b/src/main/java/friendy/community/global/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package friendy.community.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,21 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
     show-sql: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: bskfriendy@gmail.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
 friendy:
   community:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  redis:
+    host: ${REDIS_HOST}
+    port: 6379
   application:
     name: FriendyBeApplication
   datasource:
@@ -29,10 +32,12 @@ spring:
           auth: true
           starttls:
             enable: true
-            required: true
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
+  thymeleaf:
+    prefix: classpath:/templates/
+    suffix: .html
+    mode: HTML
+    encoding: UTF-8
+    cache: false
 
 friendy:
   community:

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
+    <meta charset="UTF-8">
     <title>인증번호 발송</title>
 </head>
-<body style="font-family: Arial, sans-serif; background-color: #f3f4f6; padding: 20px;">
+<body style="font-family: Arial, sans-serif; background-color: #e9e9e9; padding: 20px;">
 
     <div style="max-width: 600px; margin: 40px auto; background-color: #ffffff; border-radius: 12px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); overflow: hidden;">
 
@@ -15,9 +16,10 @@
             <h1 style="color: #1BD15D; font-size: 28px; margin-bottom: 20px;">이메일 인증 코드</h1>
             <p style="font-size: 16px; color: #555;">안녕하세요,</p>
             <p style="font-size: 16px; color: #555;">요청하신 인증번호는 아래와 같습니다:</p>
-            <h2 style="color: #1BD15D; font-size: 36px; font-weight: bold; background-color: #f3f4f6; padding: 15px 20px; border-radius: 8px; display: inline-block; margin: 20px 0;">${authCode}</h2>
+            <h2 th:text="${authCode}" style="color: #1BD15D; font-size: 36px; font-weight: bold; background-color: #f3f4f6; padding: 15px 20px; border-radius: 8px; display: inline-block; margin: 20px 0;"></h2>
             <p style="font-size: 14px; color: #777;">이 인증번호는 <strong>5분 동안 유효</strong>합니다.</p>
             <p style="font-size: 14px; color: #777;">해당 문자를 인증 코드 입력창에 입력해 주세요.</p>
+            <p style="font-size: 14px; color: #777;">만약 본인이 요청하지 않은 이메일이라면 이 메일을 무시하셔도 됩니다.</p>
         </div>
 
         <div style="background-color: #f3f4f6; padding: 20px; text-align: center;">

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -16,7 +16,7 @@
             <p style="font-size: 16px; color: #555;">안녕하세요,</p>
             <p style="font-size: 16px; color: #555;">요청하신 인증번호는 아래와 같습니다:</p>
             <h2 style="color: #1BD15D; font-size: 36px; font-weight: bold; background-color: #f3f4f6; padding: 15px 20px; border-radius: 8px; display: inline-block; margin: 20px 0;">${authCode}</h2>
-            <p style="font-size: 14px; color: #777;">이 인증번호는 <strong>30분 동안 유효</strong>합니다.</p>
+            <p style="font-size: 14px; color: #777;">이 인증번호는 <strong>5분 동안 유효</strong>합니다.</p>
             <p style="font-size: 14px; color: #777;">해당 문자를 인증 코드 입력창에 입력해 주세요.</p>
         </div>
 

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>인증번호 발송</title>
+</head>
+<body style="font-family: Arial, sans-serif; background-color: #f3f4f6; padding: 20px;">
+
+    <div style="max-width: 600px; margin: 40px auto; background-color: #ffffff; border-radius: 12px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); overflow: hidden;">
+
+        <div style="background-color: #1BD15D; padding: 20px; text-align: center;">
+            <h1 style="color: #ffffff; font-size: 32px; margin: 0;">FRIENDY</h1>
+        </div>
+
+        <div style="padding: 30px; text-align: center;">
+            <h1 style="color: #1BD15D; font-size: 28px; margin-bottom: 20px;">이메일 인증 코드</h1>
+            <p style="font-size: 16px; color: #555;">안녕하세요,</p>
+            <p style="font-size: 16px; color: #555;">요청하신 인증번호는 아래와 같습니다:</p>
+            <h2 style="color: #1BD15D; font-size: 36px; font-weight: bold; background-color: #f3f4f6; padding: 15px 20px; border-radius: 8px; display: inline-block; margin: 20px 0;">${authCode}</h2>
+            <p style="font-size: 14px; color: #777;">이 인증번호는 <strong>30분 동안 유효</strong>합니다.</p>
+            <p style="font-size: 14px; color: #777;">해당 문자를 인증 코드 입력창에 입력해 주세요.</p>
+        </div>
+
+        <div style="background-color: #f3f4f6; padding: 20px; text-align: center;">
+            <p style="margin: 0; font-size: 12px; color: #999;">Friendy Community</p>
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/src/test/java/friendy/community/domain/email/controller/EmailControllerTest.java
+++ b/src/test/java/friendy/community/domain/email/controller/EmailControllerTest.java
@@ -1,0 +1,74 @@
+package friendy.community.domain.email.controller;
+
+import friendy.community.domain.email.dto.request.EmailRequest;
+import friendy.community.domain.email.dto.request.VerifyCodeRequest;
+import friendy.community.domain.email.service.EmailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(EmailController.class)
+class EmailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @Test
+    @DisplayName("인증 코드 전송 요청이 성공하면 200 OK를 반환한다")
+    void sendAuthenticatedEmailSuccessfullyReturnsOk() throws Exception {
+        // Given
+        EmailRequest request = new EmailRequest("test@example.com");
+        doNothing().when(emailService).sendAuthenticatedEmail(request);
+
+        // When & Then
+        mockMvc.perform(post("/email/send-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test@example.com\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("인증 코드 전송 시 이메일이 없으면 400 Bad Request를 반환한다")
+    void sendAuthenticatedEmailWithoutEmailReturnsBadRequest() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/email/send-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 요청이 성공하면 200 OK를 반환한다")
+    void verifyAuthCodeSuccessfullyReturnsOk() throws Exception {
+        // Given
+        VerifyCodeRequest request = new VerifyCodeRequest("test@example.com", "123456");
+        doNothing().when(emailService).verifyAuthCode(request);
+
+        // When & Then
+        mockMvc.perform(post("/email/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test@example.com\", \"authCode\":\"123456\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 시 인증번호가 없으면 400 Bad Request를 반환한다")
+    void verifyAuthCodeWithoutAuthCodeReturnsBadRequest() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/email/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"test@example.com\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/friendy/community/domain/email/service/EmailServiceTest.java
+++ b/src/test/java/friendy/community/domain/email/service/EmailServiceTest.java
@@ -1,0 +1,136 @@
+package friendy.community.domain.email.service;
+
+import friendy.community.domain.email.dto.request.EmailRequest;
+import friendy.community.domain.email.dto.request.VerifyCodeRequest;
+import friendy.community.global.exception.ErrorCode;
+import friendy.community.global.exception.FriendyException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+
+@SpringBootTest
+@Transactional
+@DirtiesContext
+class EmailServiceTest {
+
+    @Autowired
+    private EmailService emailService;
+
+    @MockitoBean
+    private StringRedisTemplate redisTemplate;
+
+    @MockitoBean
+    private JavaMailSender mailSender;
+
+    @MockitoBean
+    private SpringTemplateEngine templateEngine;
+
+    @MockitoBean
+    private MimeMessage mimeMessage;
+
+    @Test
+    @DisplayName("이메일 전송이 성공하면 Redis에 인증 코드가 저장된다")
+    void sendAuthenticatedEmailSuccessfullyStoresCodeInRedis() throws Exception {
+        // Given
+        EmailRequest request = new EmailRequest("test@example.com");
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // Redis Mock 설정
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // TemplateEngine Mock 설정
+        when(templateEngine.process(anyString(), any())).thenReturn("<html>dummy content</html>");
+
+        // When
+        emailService.sendAuthenticatedEmail(request);
+
+        // Then
+        verify(mailSender, times(1)).send(any(MimeMessage.class));
+        verify(valueOperations, times(1)).set(
+                eq(request.email()),
+                anyString(),
+                eq(300000L),
+                eq(TimeUnit.MILLISECONDS)
+        );
+    }
+
+    @Test
+    @DisplayName("인증번호 검증이 성공하면 예외가 발생하지 않는다")
+    void verifyAuthCodeSuccessfully() {
+        // Given
+        String email = "test@example.com";
+        String authCode = "123456";
+        VerifyCodeRequest request = new VerifyCodeRequest(email, authCode);
+
+        // Mock 설정 추가
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(email)).thenReturn(authCode);
+
+        // When & Then (예외가 발생하지 않으면 성공)
+        emailService.verifyAuthCode(request);
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 인증번호가 없으면 FriendyException을 던진다")
+    void throwsExceptionWhenAuthCodeNotFound() {
+        // Given
+        String email = "test@example.com";
+        VerifyCodeRequest request = new VerifyCodeRequest(email, "123456");
+
+        // Mock 설정 추가
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(email)).thenReturn(null);
+
+        // When & Then
+        assertThatThrownBy(() -> emailService.verifyAuthCode(request))
+                .isInstanceOf(FriendyException.class)
+                .hasMessageContaining("인증번호가 존재하지 않습니다.")
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("입력된 인증번호가 저장된 인증번호와 일치하지 않으면 FriendyException을 던진다")
+    void throwsExceptionWhenAuthCodeDoesNotMatch() {
+        // Given
+        String email = "test@example.com";
+        VerifyCodeRequest request = new VerifyCodeRequest(email, "123456");
+
+        // Mock 설정 추가
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(email)).thenReturn("654321");
+
+        // When & Then
+        assertThatThrownBy(() -> emailService.verifyAuthCode(request))
+                .isInstanceOf(FriendyException.class)
+                .hasMessageContaining("인증번호가 일치하지 않습니다.")
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REQUEST);
+    }
+
+}

--- a/src/test/java/friendy/community/domain/email/service/EmailServiceTest.java
+++ b/src/test/java/friendy/community/domain/email/service/EmailServiceTest.java
@@ -4,20 +4,14 @@ import friendy.community.domain.email.dto.request.EmailRequest;
 import friendy.community.domain.email.dto.request.VerifyCodeRequest;
 import friendy.community.global.exception.ErrorCode;
 import friendy.community.global.exception.FriendyException;
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -25,9 +19,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
 
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  redis:
+    host: localhost
+    port: 6379
   application:
     name: FriendyBeApplication
   datasource:
@@ -18,6 +21,17 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
     show-sql: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: bskfriendy@gmail.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 friendy:
   community:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #32 

<br/>

## 🔎 작업 내용

- 이메일 인증코드 전송 기능
- 이메일 인증코드 검증 기능
- redis 설정 및 환경변수 설정
- redis에 인증코드 저장

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?