### PR TITLE
Feat/#42 refresh token 발급 시 redis에 저장

### DIFF
--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -10,16 +10,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/auth")
 public class AuthController implements SpringDocAuthController{
 
     private final AuthService authService;
     private final JwtTokenExtractor jwtTokenExtractor;
 
-    @PostMapping("/auth/login")
+    @PostMapping("/login")
     public ResponseEntity<Void> login(
             @Valid @RequestBody LoginRequest loginRequest
     ) {

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController implements SpringDocAuthController{
     private final AuthService authService;
     private final JwtTokenExtractor jwtTokenExtractor;
 
-    @PostMapping("/login")
+    @PostMapping("/auth/login")
     public ResponseEntity<Void> login(
             @Valid @RequestBody LoginRequest loginRequest
     ) {

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -31,6 +31,16 @@ public class AuthController implements SpringDocAuthController{
                 .build();
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<Object> logout(
+        HttpServletRequest httpServletRequest
+    ) {
+        final String accessToken = jwtTokenExtractor.extractAccessToken(httpServletRequest);
+        authService.logout(accessToken);
+
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/token/reissue")
     public ResponseEntity<Void> reissueToken(
             HttpServletRequest httpServletRequest

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -76,6 +76,24 @@ public class JwtTokenProvider {
         return extractedEmail;
     }
 
+    public long getExpirationFromAccessToken(final String token) {
+        validateAccessToken(token);
+        final Jws<Claims> claimsJws = getAccessTokenParser().parseClaimsJws(token);
+        final Date extractedDate = claimsJws.getBody().getExpiration();
+        final Date now = new Date();
+
+        return extractedDate.getTime() - now.getTime();
+    }
+
+    public long getExpirationFromRefreshToken(final String token) {
+        validateRefreshToken(token);
+        final Jws<Claims> claimsJws = getRefreshTokenParser().parseClaimsJws(token);
+        final Date extractedDate = claimsJws.getBody().getExpiration();
+        final Date now = new Date();
+
+        return extractedDate.getTime() - now.getTime();
+    }
+
     public void validateAccessToken(final String token) {
         try {
             final Claims claims = getAccessTokenParser().parseClaimsJws(token).getBody();

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -8,14 +8,9 @@ import friendy.community.domain.member.model.Member;
 import friendy.community.domain.member.repository.MemberRepository;
 import friendy.community.global.exception.ErrorCode;
 import friendy.community.global.exception.FriendyException;
-import io.netty.util.Timeout;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -26,16 +21,11 @@ public class AuthService {
     private final PasswordEncryptor passwordEncryptor;
     private final JwtTokenProvider jwtTokenProvider;
 
-    private final RedisTemplate<String, String> redisTemplate;
-
     public TokenResponse login(final LoginRequest request) {
         final Member member = getVerifiedMember(request.email(), request.password());
 
         final String accessToken = jwtTokenProvider.generateAccessToken(request.email());
         final String refreshToken = jwtTokenProvider.generateRefreshToken(request.email());
-        final long refreshTokenExpiration = jwtTokenProvider.getExpirationFromRefreshToken(refreshToken);
-
-        redisTemplate.opsForValue().set(member.getEmail(), refreshToken, refreshTokenExpiration, TimeUnit.MILLISECONDS);
 
         return TokenResponse.of(accessToken, refreshToken);
     }

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -8,9 +8,14 @@ import friendy.community.domain.member.model.Member;
 import friendy.community.domain.member.repository.MemberRepository;
 import friendy.community.global.exception.ErrorCode;
 import friendy.community.global.exception.FriendyException;
+import io.netty.util.Timeout;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -21,10 +26,16 @@ public class AuthService {
     private final PasswordEncryptor passwordEncryptor;
     private final JwtTokenProvider jwtTokenProvider;
 
+    private final RedisTemplate<String, String> redisTemplate;
+
     public TokenResponse login(final LoginRequest request) {
         final Member member = getVerifiedMember(request.email(), request.password());
+
         final String accessToken = jwtTokenProvider.generateAccessToken(request.email());
         final String refreshToken = jwtTokenProvider.generateRefreshToken(request.email());
+        final long refreshTokenExpiration = jwtTokenProvider.getExpirationFromRefreshToken(refreshToken);
+
+        redisTemplate.opsForValue().set(member.getEmail(), refreshToken, refreshTokenExpiration, TimeUnit.MILLISECONDS);
 
         return TokenResponse.of(accessToken, refreshToken);
     }

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -29,6 +29,12 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
+    public void logout(final String accessToken) {
+        jwtTokenProvider.validateAccessToken(accessToken);
+        final String email = jwtTokenProvider.extractEmailFromAccessToken(accessToken);
+        final Member member = getMemberByEmail(email);
+    }
+
     public TokenResponse reissueToken(final String refreshToken) {
         final String extractedEmail = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
         final Member member = getMemberByEmail(extractedEmail);

--- a/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
@@ -200,7 +200,7 @@ class AuthControllerTest {
         when(authService.reissueToken("refreshToken")).thenReturn(tokenResponse);
 
         // When & Then
-        mockMvc.perform(post("/token/reissue")
+        mockMvc.perform(post("/auth/token/reissue")
                         .header("Authorization-Refresh", refreshToken))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -223,7 +223,7 @@ class AuthControllerTest {
                 .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_USER, "인증 실패(잘못된 리프레시 토큰) - 토큰 : invalidRefreshToken"));
 
         // When & Then
-        mockMvc.perform(post("/token/reissue")
+        mockMvc.perform(post("/auth/token/reissue")
                         .header("Authorization-Refresh", refreshToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
@@ -244,7 +244,7 @@ class AuthControllerTest {
                 .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_USER, "인증 실패(만료된 리프레시 토큰) - 토큰 : expiredRefreshToken"));
 
         // When & Then
-        mockMvc.perform(post("/token/reissue")
+        mockMvc.perform(post("/auth/token/reissue")
                         .header("Authorization-Refresh", refreshToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
@@ -265,7 +265,7 @@ class AuthControllerTest {
                 .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_USER, "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : missingEmailClaimToken"));
 
         // When & Then
-        mockMvc.perform(post("/token/reissue")
+        mockMvc.perform(post("/auth/token/reissue")
                         .header("Authorization-Refresh", refreshToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())

--- a/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
@@ -57,7 +57,7 @@ class AuthControllerTest {
         when(authService.login(any(LoginRequest.class))).thenReturn(loginResponse);
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(loginRequest)))
                 .andDo(print())
@@ -76,7 +76,7 @@ class AuthControllerTest {
                 .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_EMAIL, "해당 이메일의 회원이 존재하지 않습니다."));
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
@@ -95,7 +95,7 @@ class AuthControllerTest {
                 .thenThrow(new FriendyException(ErrorCode.UNAUTHORIZED_PASSWORD, "로그인에 실패하였습니다. 비밀번호를 확인해주세요."));
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isUnauthorized())
@@ -111,7 +111,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest(null, "password123!");
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andDo(print())
@@ -125,7 +125,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest("invalid-email", "password123!");
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andDo(print())
@@ -139,7 +139,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest("example@friendy.com", null);
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andDo(print())
@@ -158,7 +158,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest(email, password);
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andDo(print())
@@ -177,7 +177,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest(email, password);
 
         // When & Then
-        mockMvc.perform(post("/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(request)))
                 .andDo(print())

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -1,10 +1,13 @@
 package friendy.community.domain.auth.jwt;
 
 import friendy.community.global.exception.FriendyException;
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Date;
 
 import static friendy.community.domain.auth.fixtures.TokenFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +30,40 @@ class JwtTokenProviderTest {
 
         // then
         assertThat(accessToken).isNotNull();
+    }
+
+    @Test
+    @DisplayName("액세스 토큰에서 만료까지 남은 시간을 반환한다.")
+    void getExpirationFromAceessTokenSuccessfully() {
+        // given
+        String email = "example@friendy.com";
+        String accessToken = jwtTokenProvider.generateAccessToken(email);
+
+        Date now = new Date();
+        long expireTime = 3600000L;
+
+        // when
+        long extractedTime = jwtTokenProvider.getExpirationFromAccessToken(accessToken);
+
+        // then
+        assertThat(extractedTime).isCloseTo(expireTime, Percentage.withPercentage(1));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰에서 만료까지 남은 시간을 반환한다.")
+    void getExpirationFromRefreshTokenSuccessfully() {
+        // given
+        String email = "example@friendy.com";
+        String refreshToken = jwtTokenProvider.generateRefreshToken(email);
+
+        Date now = new Date();
+        long expireTime = 2592000000L;
+
+        // when
+        long extractedTime = jwtTokenProvider.getExpirationFromRefreshToken(refreshToken);
+
+        // then
+        assertThat(extractedTime).isCloseTo(expireTime, Percentage.withPercentage(1));
     }
 
     @Test

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -33,40 +33,6 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("액세스 토큰에서 만료까지 남은 시간을 반환한다.")
-    void getExpirationFromAceessTokenSuccessfully() {
-        // given
-        String email = "example@friendy.com";
-        String accessToken = jwtTokenProvider.generateAccessToken(email);
-
-        Date now = new Date();
-        long expireTime = 3600000L;
-
-        // when
-        long extractedTime = jwtTokenProvider.getExpirationFromAccessToken(accessToken);
-
-        // then
-        assertThat(extractedTime).isCloseTo(expireTime, Percentage.withPercentage(1));
-    }
-
-    @Test
-    @DisplayName("리프레시 토큰에서 만료까지 남은 시간을 반환한다.")
-    void getExpirationFromRefreshTokenSuccessfully() {
-        // given
-        String email = "example@friendy.com";
-        String refreshToken = jwtTokenProvider.generateRefreshToken(email);
-
-        Date now = new Date();
-        long expireTime = 2592000000L;
-
-        // when
-        long extractedTime = jwtTokenProvider.getExpirationFromRefreshToken(refreshToken);
-
-        // then
-        assertThat(extractedTime).isCloseTo(expireTime, Percentage.withPercentage(1));
-    }
-
-    @Test
     @DisplayName("엑세스 토큰에서 이메일을 추출한다")
     void extractEmailFromAccessTokenSuccessfully() {
         // given

--- a/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
@@ -11,11 +11,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static friendy.community.domain.auth.fixtures.TokenFixtures.CORRECT_REFRESH_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Transactional
@@ -28,9 +33,16 @@ class AuthServiceTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @MockitoBean
+    private StringRedisTemplate redisTemplate;
+
     @Test
     @DisplayName("로그인 성공 시 액세스 토큰과 리프레시 토큰이 생성된다.")
     void loginSuccessfullyGeneratesTokens() {
+        // Redis Mock 셋업
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
         // Given
         Member savedMember = memberRepository.save(MemberFixture.memberFixture());
         LoginRequest loginRequest = new LoginRequest(savedMember.getEmail(), MemberFixture.getFixturePlainPassword());
@@ -71,6 +83,10 @@ class AuthServiceTest {
     @Test
     @DisplayName("토큰 재발급 성공 시 새로운 액세스 토큰과 리프레시 토큰이 반환된다.")
     void reissueTokenSuccessfullyReturnsNewTokens() {
+        // Redis Mock 셋업
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
         // Given
         Member savedMember = memberRepository.save(MemberFixture.memberFixture());
         String refreshToken = CORRECT_REFRESH_TOKEN;

--- a/src/test/java/friendy/community/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/friendy/community/domain/member/service/MemberServiceTest.java
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -41,9 +43,11 @@ class MemberServiceTest {
 
         // When
         Long savedId = memberService.signUp(memberSignUpRequest);
+        Optional<Member> actualMember = memberRepository.findById(savedId);
 
         // Then
-        assertThat(savedId).isEqualTo(1L);
+        assertThat(actualMember).isPresent();
+        assertThat(actualMember.get().getEmail()).isEqualTo(member.getEmail());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #42 

<br/>

## 🔎 작업 내용

- `JwtTokenProvider.generateRefreshToken` 메서드: `saveTokenExpiration` 메서드를 통해 토큰 발급 시 redis에 저장

- `JwtTokenProvider.saveTokenExpiration` 메서드: redis에 이메일(key), refreshToken(value) 저장

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 메서드를 생각없이 `saveTokenExpiration`라고 지었는데 Value 값이 refreshToken이니 `saveRefreshToken`이 메소드명으로 더 적합할까요? 의견 남겨주세요