### PR TITLE
Feat/#33 로그아웃 API 구현

### DIFF
--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -37,8 +37,9 @@ public class AuthController implements SpringDocAuthController{
     public ResponseEntity<Void> logout(
         HttpServletRequest httpServletRequest
     ) {
+        final String accessToken = jwtTokenExtractor.extractAccessToken(httpServletRequest);
         final String refreshToken = jwtTokenExtractor.extractRefreshToken(httpServletRequest);
-        authService.logout(refreshToken);
+        authService.logout(accessToken, refreshToken);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController implements SpringDocAuthController{
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Object> logout(
+    public ResponseEntity<Void> logout(
         HttpServletRequest httpServletRequest
     ) {
         final String refreshToken = jwtTokenExtractor.extractRefreshToken(httpServletRequest);

--- a/src/main/java/friendy/community/domain/auth/controller/AuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/AuthController.java
@@ -37,8 +37,8 @@ public class AuthController implements SpringDocAuthController{
     public ResponseEntity<Object> logout(
         HttpServletRequest httpServletRequest
     ) {
-        final String accessToken = jwtTokenExtractor.extractAccessToken(httpServletRequest);
-        authService.logout(accessToken);
+        final String refreshToken = jwtTokenExtractor.extractRefreshToken(httpServletRequest);
+        authService.logout(refreshToken);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
+++ b/src/main/java/friendy/community/domain/auth/controller/SpringDocAuthController.java
@@ -23,18 +23,33 @@ public interface SpringDocAuthController {
                     @Header(name = "Authorization-Refresh", description = "리프레시 토큰", required = true, schema = @Schema(type = "string"))
             }
     )
-    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/login", errorCases = {
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/auth/login", errorCases = {
             @ErrorCase(description = "이메일 입력 없음", exampleMessage = "이메일이 입력되지 않았습니다."),
             @ErrorCase(description = "이메일 형식 오류", exampleMessage = "이메일 형식으로 입력해주세요."),
             @ErrorCase(description = "비밀번호 입력 없음", exampleMessage = "비밀번호가 입력되지 않았습니다."),
             @ErrorCase(description = "비밀번호 형식 오류", exampleMessage = "숫자, 영문자, 특수문자(~!@#$%^&*?)를 포함해야 합니다."),
             @ErrorCase(description = "비밀번호 글자수 오류", exampleMessage = "비밀번호는 8~16자 사이로 입력해주세요."),
     })
-    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/login", errorCases = {
+    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/auth/login", errorCases = {
             @ErrorCase(description = "이메일 불일치", exampleMessage = "해당 이메일의 회원이 존재하지 않습니다."),
             @ErrorCase(description = "비밀번호 불일치", exampleMessage = "로그인에 실패하였습니다. 비밀번호를 확인해주세요."),
     })
     ResponseEntity<Void> login(LoginRequest request);
+
+    @Operation(
+            summary = "로그아웃",
+            security = {
+                    @SecurityRequirement(name = "bearerAuth"),
+                    @SecurityRequirement(name = "refreshAuth")
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/auth/logout", errorCases = {
+            @ErrorCase(description = "잘못된 리프레시 토큰", exampleMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : {token}"),
+            @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : {token}"),
+            @ErrorCase(description = "리프레시 토큰에 이메일 클레임 없음", exampleMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : {token}")
+    })
+    ResponseEntity<Void> logout(HttpServletRequest httpServletRequest);
 
     @Operation(
             summary = "토큰 재발급",
@@ -49,7 +64,7 @@ public interface SpringDocAuthController {
                     @Header(name = "Authorization-Refresh", description = "새로운 리프레시 토큰", required = true, schema = @Schema(type = "string"))
             }
     )
-    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/token/reissue", errorCases = {
+    @ApiErrorResponse(status = HttpStatus.UNAUTHORIZED, instance = "/auth/token/reissue", errorCases = {
             @ErrorCase(description = "잘못된 리프레시 토큰", exampleMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : {token}"),
             @ErrorCase(description = "리프레시 토큰 만료", exampleMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : {token}"),
             @ErrorCase(description = "리프레시 토큰에 이메일 클레임 없음", exampleMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : {token}")

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -84,6 +84,10 @@ public class JwtTokenProvider {
     }
 
     public void validateRefreshToken(final String token) {
+        if (!redisTemplate.hasKey(extractEmailFromRefreshToken(token))) {
+            final String logMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
+        }
         try {
             final Claims claims = getRefreshTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -136,10 +136,8 @@ public class JwtTokenProvider {
     }
 
     public void deleteRefreshToken(final String email) {
-        if (redisTemplate.hasKey(email))
-            redisTemplate.delete(email);
-        else
+        if (!redisTemplate.hasKey(email))
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, "로그인 되어있지 않은 사용자입니다.");
+        boolean isEmailExists = redisTemplate.delete(email);
     }
-
 }

--- a/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/friendy/community/domain/auth/jwt/JwtTokenProvider.java
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
             final String logMessage = "인증 실패(JWT 리프레시 토큰 Payload 이메일 누락) - 토큰 : " + token;
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         }
-
+        validateRefreshToken(token, extractedEmail);
         return extractedEmail;
     }
 
@@ -83,17 +83,20 @@ public class JwtTokenProvider {
         }
     }
 
-    public void validateRefreshToken(final String token) {
-        if (!redisTemplate.hasKey(extractEmailFromRefreshToken(token))) {
-            final String logMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : " + token;
-            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
-        }
+    private void validateRefreshToken(final String token) {
         try {
             final Claims claims = getRefreshTokenParser().parseClaimsJws(token).getBody();
         } catch (MalformedJwtException | UnsupportedJwtException e) {
             final String logMessage = "인증 실패(잘못된 리프레시 토큰) - 토큰 : " + token;
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         } catch (ExpiredJwtException e) {
+            final String logMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : " + token;
+            throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
+        }
+    }
+
+    private void validateRefreshToken(final String token, final String email) {
+        if (!redisTemplate.hasKey(email)) {
             final String logMessage = "인증 실패(만료된 리프레시 토큰) - 토큰 : " + token;
             throw new FriendyException(ErrorCode.UNAUTHORIZED_USER, logMessage);
         }

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -31,7 +31,6 @@ public class AuthService {
     }
 
     public void logout(final String refreshToken) {
-        jwtTokenProvider.validateRefreshToken(refreshToken);
         final String email = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
 
         jwtTokenProvider.deleteRefreshToken(email);

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -30,10 +30,11 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
-    public void logout(final String accessToken) {
-        jwtTokenProvider.validateAccessToken(accessToken);
-        final String email = jwtTokenProvider.extractEmailFromAccessToken(accessToken);
-        final Member member = getMemberByEmail(email);
+    public void logout(final String refreshToken) {
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+        final String email = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
+
+        jwtTokenProvider.deleteRefreshToken(email);
     }
 
     public TokenResponse reissueToken(final String refreshToken) {

--- a/src/main/java/friendy/community/domain/auth/service/AuthService.java
+++ b/src/main/java/friendy/community/domain/auth/service/AuthService.java
@@ -30,7 +30,8 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
-    public void logout(final String refreshToken) {
+    public void logout(final String accessToken, final String refreshToken) {
+        jwtTokenProvider.validateAccessToken(accessToken);
         final String email = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);
 
         jwtTokenProvider.deleteRefreshToken(email);

--- a/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/friendy/community/domain/auth/controller/AuthControllerTest.java
@@ -186,6 +186,23 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("로그아웃이 성공적으로 처리되면 200 OK를 반환한다.")
+    void logoutSuccessfullyReturns200Ok() throws Exception {
+        // Given
+        String refreshToken = "Bearer refreshToken";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization-Refresh", "Bearer refreshToken");
+
+        when(jwtTokenExtractor.extractRefreshToken(any(HttpServletRequest.class)))
+                .thenReturn("refreshToken");
+
+        mockMvc.perform(post("/auth/logout")
+                        .header("Authorization-Refresh", refreshToken))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("토큰 재발급 요청이 성공적으로 처리되면 200 OK와 함께 새로운 토큰 헤더가 반환된다")
     void reissueTokenSuccessfullyReturnsNewTokensInHeaders() throws Exception {
         // Given

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -1,5 +1,6 @@
 package friendy.community.domain.auth.jwt;
 
+import friendy.community.domain.auth.service.AuthService;
 import friendy.community.global.exception.FriendyException;
 import org.assertj.core.data.Percentage;
 import org.hamcrest.number.IsCloseTo;
@@ -123,6 +124,8 @@ class JwtTokenProviderTest {
         // given
         String email = "example@friendy.com";
         String refreshToken = jwtTokenProvider.generateRefreshToken(email);
+
+        when(redisTemplate.hasKey(email)).thenReturn(true);
 
         // when
         String extractedEmail = jwtTokenProvider.extractEmailFromRefreshToken(refreshToken);

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -188,4 +188,22 @@ class JwtTokenProviderTest {
                 .isInstanceOf(FriendyException.class)
                 .hasMessageContaining("인증 실패(만료된 리프레시 토큰) - 토큰 : " + refreshToken);
     }
+
+    @Test
+    @DisplayName("로그인 되어있지 않은 상태인 사용자의 토큰을 Redis에서 삭제하려 하면 예외를 발생시킨다.")
+    void throwExceptionForDeleteRefreshTokenInRedisWithNotLoggedInUsersEmail() {
+        // Redis Mock 설정
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // Given
+        String email = "notLoggedInUser@friendy.com";
+
+        when(redisTemplate.hasKey(email)).thenReturn(false);
+
+        // When & Then
+        assertThatThrownBy(() -> jwtTokenProvider.deleteRefreshToken(email))
+                .isInstanceOf(FriendyException.class)
+                .hasMessageContaining("로그인 되어있지 않은 사용자입니다.");
+    }
 }

--- a/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/friendy/community/domain/auth/jwt/JwtTokenProviderTest.java
@@ -186,7 +186,7 @@ class JwtTokenProviderTest {
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.extractEmailFromRefreshToken(refreshToken))
                 .isInstanceOf(FriendyException.class)
-                .hasMessageContaining("인증 실패(만료된 리프레시 토큰) - 토큰 : " + refreshToken);
+                .hasMessageContaining("인증 실패(등록되지 않은 리프레시 토큰) - 토큰 : " + refreshToken);
     }
 
     @Test

--- a/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
@@ -83,13 +83,14 @@ class AuthServiceTest {
     @Test
     @DisplayName("토큰 재발급 성공 시 새로운 액세스 토큰과 리프레시 토큰이 반환된다.")
     void reissueTokenSuccessfullyReturnsNewTokens() {
-        // Redis Mock 셋업
-        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-
         // Given
         Member savedMember = memberRepository.save(MemberFixture.memberFixture());
         String refreshToken = CORRECT_REFRESH_TOKEN;
+
+        // Redis Mock 셋업
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.hasKey("example@friendy.com")).thenReturn(true);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // When
         TokenResponse response = authService.reissueToken(refreshToken);

--- a/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/friendy/community/domain/auth/service/AuthServiceTest.java
@@ -129,7 +129,7 @@ class AuthServiceTest {
         // When & Then
         assertThatThrownBy(() -> authService.logout(accessToken, refreshToken))
                 .isInstanceOf(FriendyException.class)
-                .hasMessageContaining("인증 실패(만료된 리프레시 토큰) - 토큰 : " + refreshToken);
+                .hasMessageContaining("인증 실패(등록되지 않은 리프레시 토큰) - 토큰 : " + refreshToken);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #33

<br/>

## 🔎 작업 내용

- 로그아웃 컨트롤러 구현
- 로그아웃 서비스 구현
- redis 연동 (로그아웃 요청시 redis에서 리프레시 토큰 삭제)
- 로그아웃 API 테스트 작성

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)
> redis에 리프레시 토큰이 등록되어 있는지 검사하기 위해 토큰에서 이메일을 추출하는 작업이 필요한데, 이메일을 추출하는 메서드에서 토큰 유효성을 검사하고 있어 중복 호출로 인한 스택 오버플로우 예외가 발생합니다.
이를 해결하기 위해 validateRefreshToken 메서드를 오버로드하여 사용하였으나, 이로 인해 코드의 가독성과 사용성이 저하되었다고 판단됩니다.
추후 리팩토링 작업이 필요할 것 같습니다.