### PR TITLE
Feat/#56 게시글 해시태그 추가

### DIFF
--- a/src/main/java/friendy/community/domain/hashtag/model/Hashtag.java
+++ b/src/main/java/friendy/community/domain/hashtag/model/Hashtag.java
@@ -1,0 +1,24 @@
+package friendy.community.domain.hashtag.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode(of = "id", callSuper = false)
+public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Hashtag(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/friendy/community/domain/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/friendy/community/domain/hashtag/repository/HashtagRepository.java
@@ -1,0 +1,12 @@
+package friendy.community.domain.hashtag.repository;
+
+import friendy.community.domain.hashtag.model.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    List<Hashtag> findAllByNameIn(List<String> names);
+}

--- a/src/main/java/friendy/community/domain/hashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/friendy/community/domain/hashtag/repository/PostHashtagRepository.java
@@ -1,0 +1,9 @@
+package friendy.community.domain.hashtag.repository;
+
+import friendy.community.domain.post.model.PostHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+}

--- a/src/main/java/friendy/community/domain/hashtag/repository/PostHashtagRepository.java
+++ b/src/main/java/friendy/community/domain/hashtag/repository/PostHashtagRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
@@ -30,6 +30,10 @@ public class HashtagService {
         savePostHashtags(post, existTags);
     }
 
+    public void deleteHashtags(Long postId) {
+        postHashtagRepository.deleteAllByPostId(postId);
+    }
+
     private List<String> getExistHashtagNames(List<Hashtag> existTags) {
         return existTags.stream()
                 .map(Hashtag::getName)

--- a/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
@@ -1,0 +1,54 @@
+package friendy.community.domain.hashtag.service;
+
+import friendy.community.domain.hashtag.model.Hashtag;
+import friendy.community.domain.hashtag.repository.HashtagRepository;
+import friendy.community.domain.hashtag.repository.PostHashtagRepository;
+import friendy.community.domain.post.model.Post;
+import friendy.community.domain.post.model.PostHashtag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+    private final PostHashtagRepository postHashtagRepository;
+
+    public void saveHashtags(Post post, List<String> hashtagNames) {
+        List<Hashtag> existTags = hashtagRepository.findAllByNameIn(hashtagNames);
+        List<String> existNames = getExistHashtagNames(existTags);
+
+        List<Hashtag> newHashtags = getOnlyNewHashags(existNames, hashtagNames);
+        List<Hashtag> savedNewHashtags = hashtagRepository.saveAll(newHashtags);
+
+        existTags.addAll(savedNewHashtags);
+        savePostHashtags(post, existTags);
+    }
+
+    private List<String> getExistHashtagNames(List<Hashtag> existTags) {
+        return existTags.stream()
+                .map(Hashtag::getName)
+                .toList();
+    }
+
+    private List<Hashtag> getOnlyNewHashags(List<String> existNames, List<String> hashtagNames) {
+        return hashtagNames.stream()
+                .distinct()
+                .filter(name -> !existNames.contains(name))
+                .map(Hashtag::new)
+                .toList();
+    }
+
+    private void savePostHashtags(Post post, List<Hashtag> hashtags) {
+        List<PostHashtag> postHashtags = hashtags.stream()
+                .map(hashtag -> new PostHashtag(post, hashtag))
+                .toList();
+        postHashtagRepository.saveAll(postHashtags);
+    }
+
+}

--- a/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
+++ b/src/main/java/friendy/community/domain/hashtag/service/HashtagService.java
@@ -30,6 +30,11 @@ public class HashtagService {
         savePostHashtags(post, existTags);
     }
 
+    public void updateHashtags(Post post, List<String> hashtags) {
+        deleteHashtags(post.getId());
+        saveHashtags(post, hashtags);
+    }
+
     public void deleteHashtags(Long postId) {
         postHashtagRepository.deleteAllByPostId(postId);
     }

--- a/src/main/java/friendy/community/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/friendy/community/domain/post/dto/request/PostCreateRequest.java
@@ -3,13 +3,17 @@ package friendy.community.domain.post.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
+import java.util.List;
+
 @Schema(description = "게시판 생성")
 public record PostCreateRequest(
 
         @Schema(description = "게시글 내용", example = "프렌디게시글내용")
         @NotBlank(message = "게시글 내용이 입력되지 않았습니다.")
         @Size(max = 2200, message = "게시글은 2200자 이내로 작성해주세요.")
-        String content
+        String content,
 
+        @Schema(description = "게시글 해시태그", example = "[\"프렌디\", \"개발\", \"스터디\"]")
+        List<String> hashtags
 ) {
 }

--- a/src/main/java/friendy/community/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/friendy/community/domain/post/dto/request/PostUpdateRequest.java
@@ -3,11 +3,17 @@ package friendy.community.domain.post.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
+import java.util.List;
+
 @Schema(description = "게시글 수정")
 public record PostUpdateRequest(
-    @Schema(description = "게시글 내용", example = "프렌디게시글내용업데이트")
-    @NotBlank(message = "게시글 내용이 입력되지 않았습니다")
-    @Size(max = 2200, message = "게시글은 2200자 이내로 작성해주세요.")
-    String content
+
+        @Schema(description = "게시글 내용", example = "프렌디게시글내용")
+        @NotBlank(message = "게시글 내용이 입력되지 않았습니다.")
+        @Size(max = 2200, message = "게시글은 2200자 이내로 작성해주세요.")
+        String content,
+
+        @Schema(description = "게시글 해시태그", example = "[\"프렌디\", \"개발\", \"스터디\"]")
+        List<String> hashtags
 ) {
 }

--- a/src/main/java/friendy/community/domain/post/model/PostHashtag.java
+++ b/src/main/java/friendy/community/domain/post/model/PostHashtag.java
@@ -1,0 +1,44 @@
+package friendy.community.domain.post.model;
+
+import friendy.community.domain.hashtag.model.Hashtag;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id", callSuper = false)
+public class PostHashtag {
+
+    @Embeddable
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    protected static class TemplateTagId implements Serializable {
+        private Long postId;
+        private Long hashtagId;
+    }
+
+    @EmbeddedId
+    private TemplateTagId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("postId")
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("hashtagId")
+    @JoinColumn(name = "hashtag_id")
+    private Hashtag hashtag;
+
+    public PostHashtag(Post post, Hashtag hashtag) {
+        this.id = new TemplateTagId(post.getId(), hashtag.getId());
+        this.post = post;
+        this.hashtag = hashtag;
+    }
+
+}

--- a/src/test/java/friendy/community/domain/hashtag/model/HashtagTest.java
+++ b/src/test/java/friendy/community/domain/hashtag/model/HashtagTest.java
@@ -1,0 +1,25 @@
+package friendy.community.domain.hashtag.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class HashtagTest {
+
+    @Test
+    @DisplayName("Hashtag 객체가 요청을 기반으로 생성되는지 테스트")
+    void createHashtagSuccessfully() {
+        // Given
+        String name = "프렌디";
+
+        // When
+        Hashtag hashtag = new Hashtag(name);
+
+        // Then
+        assertThat(hashtag).isNotNull();
+        assertThat(hashtag.getName()).isEqualTo(name);
+    }
+}

--- a/src/test/java/friendy/community/domain/hashtag/service/HashtagServiceTest.java
+++ b/src/test/java/friendy/community/domain/hashtag/service/HashtagServiceTest.java
@@ -1,0 +1,107 @@
+package friendy.community.domain.hashtag.service;
+
+import friendy.community.domain.hashtag.model.Hashtag;
+import friendy.community.domain.hashtag.repository.HashtagRepository;
+import friendy.community.domain.hashtag.repository.PostHashtagRepository;
+import friendy.community.domain.member.fixture.MemberFixture;
+import friendy.community.domain.member.model.Member;
+import friendy.community.domain.member.repository.MemberRepository;
+import friendy.community.domain.post.model.Post;
+import friendy.community.domain.post.model.PostHashtag;
+import friendy.community.domain.post.repository.PostRepository;
+import friendy.community.domain.post.dto.request.PostCreateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@DirtiesContext
+class HashtagServiceTest {
+
+    @Autowired
+    private HashtagService hashtagService;
+    @Autowired
+    private HashtagRepository hashtagRepository;
+    @Autowired
+    private PostHashtagRepository postHashtagRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Post post;
+
+    @BeforeEach
+    void setup() {
+        Member member = MemberFixture.memberFixture();
+        memberRepository.save(member);
+
+        PostCreateRequest postCreateRequest = new PostCreateRequest("This is a test post", List.of());
+        post = Post.of(postCreateRequest, member);
+        postRepository.save(post);
+    }
+
+    @Test
+    @DisplayName("게시글에 해시태그를 추가하면 PostHashtag도 함께 저장된다")
+    void saveHashtagsSuccessfullySavesPostHashtags() {
+        // Given
+        List<String> hashtagNames = List.of("프렌디", "개발", "스터디");
+
+        // When
+        hashtagService.saveHashtags(post, hashtagNames);
+
+        // Then
+        List<Hashtag> savedHashtags = hashtagRepository.findAll();
+        assertThat(savedHashtags).hasSize(3);
+        assertThat(savedHashtags).extracting(Hashtag::getName).containsExactlyInAnyOrder("프렌디", "개발", "스터디");
+
+        List<PostHashtag> postHashtags = postHashtagRepository.findAll();
+        assertThat(postHashtags).hasSize(3);
+        assertThat(postHashtags).extracting(postHashtag -> postHashtag.getHashtag().getName())
+                .containsExactlyInAnyOrder("프렌디", "개발", "스터디");
+    }
+
+    @Test
+    @DisplayName("게시글 해시태그를 수정하면 기존 PostHashtag가 삭제되고 새 해시태그가 저장된다")
+    void updateHashtagsSuccessfullyUpdatesPostHashtags() {
+        // Given
+        List<String> initialHashtags = List.of("프렌디", "개발");
+        hashtagService.saveHashtags(post, initialHashtags);
+
+        List<String> updatedHashtags = List.of("스터디", "코딩");
+
+        // When
+        hashtagService.updateHashtags(post, updatedHashtags);
+
+        // Then
+        List<PostHashtag> postHashtags = postHashtagRepository.findAll();
+        assertThat(postHashtags).hasSize(2);
+        assertThat(postHashtags).extracting(postHashtag -> postHashtag.getHashtag().getName())
+                .containsExactlyInAnyOrder("스터디", "코딩");
+    }
+
+    @Test
+    @DisplayName("게시글이 삭제되면 해당 게시글의 PostHashtag도 함께 삭제된다")
+    void deleteHashtagsSuccessfullyRemovesPostHashtags() {
+        // Given
+        List<String> hashtags = List.of("프렌디", "개발", "스터디");
+        hashtagService.saveHashtags(post, hashtags);
+
+        // When
+        hashtagService.deleteHashtags(post.getId());
+
+        // Then
+        List<PostHashtag> postHashtags = postHashtagRepository.findAll();
+        assertThat(postHashtags).isEmpty();
+    }
+}

--- a/src/test/java/friendy/community/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/friendy/community/domain/post/controller/PostControllerTest.java
@@ -3,8 +3,8 @@ package friendy.community.domain.post.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import friendy.community.domain.post.dto.request.PostCreateRequest;
 import friendy.community.domain.post.dto.request.PostUpdateRequest;
-import friendy.community.domain.post.dto.response.FindMemberResponse;
 import friendy.community.domain.post.dto.response.FindAllPostResponse;
+import friendy.community.domain.post.dto.response.FindMemberResponse;
 import friendy.community.domain.post.dto.response.FindPostResponse;
 import friendy.community.domain.post.service.PostService;
 import friendy.community.global.exception.ErrorCode;
@@ -14,15 +14,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -37,145 +33,129 @@ class PostControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-
     @Autowired
     private ObjectMapper objectMapper;
-
     @MockitoBean
     private PostService postService;
 
+    private static final String BASE_URL = "/posts";
 
     private String generateLongContent(int length) {
         return "a".repeat(length);
     }
 
     @Test
-    @DisplayName("포스트 생성 요청이 성공적으로 처리되면 201 Created와 함께 응답을 반환한다")
-    public void createPostSuccessfullyReturns201Created() throws Exception {
-        //Given
-        PostCreateRequest postCreateRequest = new PostCreateRequest("this is new content");
-
-        //When
+    @DisplayName("게시글 생성 성공 시 201 Created 응답")
+    void createPostSuccessfullyReturns201Created() throws Exception {
+        // Given
+        PostCreateRequest request = new PostCreateRequest("this is new content", List.of("프렌디", "개발", "스터디"));
         when(postService.savePost(any(PostCreateRequest.class), any(HttpServletRequest.class))).thenReturn(1L);
 
-        //Then
-        mockMvc.perform(post("/posts")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(postCreateRequest)))
-            .andDo(print()).andExpect(status().isCreated())
-            .andExpect(header().string("Location", "/posts/1"));
-
+        // When & Then
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/posts/1"));
     }
 
     @Test
-    @DisplayName("포스트 생성에 content가 없으면 400 Bad Request를 반환한다")
+    @DisplayName("게시글 내용이 없으면 400 Bad Request 반환")
     void createPostWithoutContentReturns400BadRequest() throws Exception {
-        //Given
-        PostCreateRequest postCreateRequest = new PostCreateRequest(null);
+        // Given
+        PostCreateRequest request = new PostCreateRequest(null, List.of("프렌디", "개발", "스터디"));
 
-        //When
-        when(postService.savePost(any(PostCreateRequest.class), any(HttpServletRequest.class))).thenReturn(1L);
-
-        //Then
-        mockMvc.perform(post("/posts")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(postCreateRequest)))
-            .andDo(print()).andExpect(status().isBadRequest());
+        // When & Then
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("content가 2200자가 넘어가면 400 Bad Request를 반환한다")
+    @DisplayName("게시글 내용이 2200자 초과 시 400 Bad Request 반환")
     void createPostWithContentExceedingMaxLengthReturns400BadRequest() throws Exception {
-        //Given
-        PostCreateRequest postCreateRequest = new PostCreateRequest(generateLongContent(2300));
+        // Given
+        PostCreateRequest request = new PostCreateRequest(generateLongContent(2300), List.of("프렌디", "개발", "스터디"));
 
-        //When
-        when(postService.savePost(any(PostCreateRequest.class), any(HttpServletRequest.class))).thenReturn(1L);
-
-        //Then
-        mockMvc.perform(post("/posts")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(postCreateRequest)))
-            .andDo(print()).andExpect(status().isBadRequest());
+        // When & Then
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("포스트 수정 요청이 성공적으로 처리되면 201 Created와 함께 응답을 반환한다")
-    public void updatePostSuccessfullyReturns201Created() throws Exception {
-        //Given
+    @DisplayName("게시글 수정 성공 시 201 Created 응답")
+    void updatePostSuccessfullyReturns201Created() throws Exception {
+        // Given
         Long postId = 1L;
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest("this is updated content");
-
-        //When
+        PostUpdateRequest request = new PostUpdateRequest("this is updated content", List.of("프렌디", "개발", "스터디"));
         when(postService.updatePost(any(PostUpdateRequest.class), any(HttpServletRequest.class), anyLong())).thenReturn(1L);
 
-
-        //Then
-        mockMvc.perform(post("/posts/{postId}", postId)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(postUpdateRequest)))
-            .andDo(print()).andExpect(status().isCreated());
+        // When & Then
+        mockMvc.perform(post(BASE_URL + "/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated());
     }
 
     @Test
-    @DisplayName("포스트 수정에 content가 2200자가 넘어가면 400 Bad Request를 반환한다")
+    @DisplayName("게시글 수정 시 내용이 2200자 초과하면 400 Bad Request 반환")
     void updatePostWithContentExceedingMaxLengthReturns400BadRequest() throws Exception {
-        //Given
+        // Given
         Long postId = 1L;
-        PostUpdateRequest postUpdateRequest = new PostUpdateRequest(generateLongContent(2300));
+        PostUpdateRequest request = new PostUpdateRequest(generateLongContent(2300), List.of("프렌디", "개발", "스터디"));
 
-        //When
-        when(postService.updatePost(any(PostUpdateRequest.class), any(HttpServletRequest.class), anyLong())).thenReturn(1L);
-
-        //Then
-        mockMvc.perform(post("/posts/{postId}", postId)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(postUpdateRequest)))
-            .andDo(print()).andExpect(status().isBadRequest());
+        // When & Then
+        mockMvc.perform(post(BASE_URL + "/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("포스트 삭제 요청이 성공적으로 처리되면 200 OK와 함께 응답을 반환한다")
-    public void deletePostSuccessfullyReturns200Ok() throws Exception {
-        //Given
+    @DisplayName("게시글 삭제 성공 시 200 OK 응답")
+    void deletePostSuccessfullyReturns200Ok() throws Exception {
+        // Given
         Long postId = 1L;
+        doNothing().when(postService).deletePost(any(HttpServletRequest.class), eq(postId));
 
-        //When
-        doNothing().when(postService).deletePost(any(HttpServletRequest.class), eq(postId)); // 서비스 메서드가 아무 동작도 하지 않도록 설정
-
-        //Then
-        mockMvc.perform(delete("/posts/{postId}", postId)
-                .contentType(MediaType.APPLICATION_JSON))
+        // When & Then
+        mockMvc.perform(delete(BASE_URL + "/{postId}", postId)
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("게시글 조회 성공 시 200 OK와 게시글 정보를 반환한다")
+    @DisplayName("게시글 조회 성공 시 200 OK 및 게시글 반환")
     void getPostSuccessfullyReturns200Ok() throws Exception {
         // Given
         Long postId = 1L;
         FindPostResponse response = new FindPostResponse(1L, "Post 1", "2025-01-23T10:00:00", 10, 5, 2, new FindMemberResponse(1L, "author1"));
-
         when(postService.getPost(anyLong())).thenReturn(response);
 
         // When & Then
-        mockMvc.perform(get("/posts/{postId}", postId)
+        mockMvc.perform(get(BASE_URL + "/{postId}", postId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("존재하지 않는 게시글을 조회하면 404 Not Found를 반환한다")
+    @DisplayName("존재하지 않는 게시글 조회 시 404 Not Found 반환")
     void getPostWithNonExistentIdReturns404NotFound() throws Exception {
         // Given
         Long nonExistentPostId = 999L;
-
-        when(postService.getPost(anyLong()))
-                .thenThrow(new FriendyException(ErrorCode.RESOURCE_NOT_FOUND, "존재하지 않는 게시글입니다."));
+        when(postService.getPost(anyLong())).thenThrow(new FriendyException(ErrorCode.RESOURCE_NOT_FOUND, "존재하지 않는 게시글입니다."));
 
         // When & Then
-        mockMvc.perform(get("/posts/{postId}", nonExistentPostId)
+        mockMvc.perform(get(BASE_URL + "/{postId}", nonExistentPostId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isNotFound())
@@ -184,7 +164,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("게시글 목록 조회 성공 시 200 OK 반환")
-    public void getPostsListSuccessfullyReturns200Ok() throws Exception {
+    void getPostsListSuccessfullyReturns200Ok() throws Exception {
         // Given
         List<FindPostResponse> posts = List.of(
                 new FindPostResponse(1L, "Post 1", "2025-01-23T10:00:00", 10, 5, 2, new FindMemberResponse(1L, "author1")),
@@ -193,23 +173,22 @@ class PostControllerTest {
         when(postService.getAllPosts(any(Pageable.class)))
                 .thenReturn(new FindAllPostResponse(posts, 1));
 
-        // Then
-        mockMvc.perform(get("/posts/list").param("page", "0"))
+        // When & Then
+        mockMvc.perform(get(BASE_URL + "/list").param("page", "0"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("없는 페이지 요청 시 404 반환")
-    public void getPostsListWithNonExistentPageReturns404NotFound() throws Exception {
+    @DisplayName("없는 페이지 요청 시 404 Not Found 반환")
+    void getPostsListWithNonExistentPageReturns404NotFound() throws Exception {
         // Given
         when(postService.getAllPosts(any(Pageable.class)))
                 .thenThrow(new FriendyException(ErrorCode.RESOURCE_NOT_FOUND, "요청한 페이지가 존재하지 않습니다."));
 
-        // Then
-        mockMvc.perform(get("/posts/list").param("page", "100"))
+        // When & Then
+        mockMvc.perform(get(BASE_URL + "/list").param("page", "100"))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.detail").value("요청한 페이지가 존재하지 않습니다."));
     }
-
 }

--- a/src/test/java/friendy/community/domain/post/fixture/PostFixture.java
+++ b/src/test/java/friendy/community/domain/post/fixture/PostFixture.java
@@ -1,0 +1,20 @@
+package friendy.community.domain.post.fixture;
+
+import friendy.community.domain.member.fixture.MemberFixture;
+import friendy.community.domain.member.model.Member;
+import friendy.community.domain.post.dto.request.PostCreateRequest;
+import friendy.community.domain.post.model.Post;
+
+import java.util.List;
+
+public class PostFixture {
+
+    public static Post postFixture() {
+        return createPost("This is a sample post content.", List.of("프렌디", "개발", "스터디"));
+    }
+
+    public static Post createPost(String content, List<String> hashtags) {
+        Member member = MemberFixture.memberFixture();
+        return Post.of(new PostCreateRequest(content, hashtags), member);
+    }
+}

--- a/src/test/java/friendy/community/domain/post/model/PostHashtagTest.java
+++ b/src/test/java/friendy/community/domain/post/model/PostHashtagTest.java
@@ -1,0 +1,41 @@
+package friendy.community.domain.post.model;
+
+import friendy.community.domain.hashtag.model.Hashtag;
+import friendy.community.domain.member.fixture.MemberFixture;
+import friendy.community.domain.post.dto.request.PostCreateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+class PostHashtagTest {
+
+    private Post post;
+    private Hashtag hashtag;
+
+    @BeforeEach
+    void setUp() {
+        PostCreateRequest postCreateRequest = new PostCreateRequest("This is a new post content.", List.of("프렌디", "개발", "스터디"));
+        post = new Post(postCreateRequest, MemberFixture.memberFixture());
+        hashtag = new Hashtag("프렌디");
+    }
+
+    @Test
+    @DisplayName("PostHashtag 객체가 요청을 기반으로 생성되는지 테스트")
+    void postHashtagCreatesSuccessfully() {
+        // Given & When
+        PostHashtag postHashtag = new PostHashtag(post, hashtag);
+
+        // Then
+        assertNotNull(postHashtag);
+        assertEquals(post, postHashtag.getPost());
+        assertEquals(hashtag, postHashtag.getHashtag());
+    }
+}
+

--- a/src/test/java/friendy/community/domain/post/model/PostTest.java
+++ b/src/test/java/friendy/community/domain/post/model/PostTest.java
@@ -1,6 +1,5 @@
 package friendy.community.domain.post.model;
 
-import friendy.community.domain.member.dto.request.MemberSignUpRequest;
 import friendy.community.domain.member.fixture.MemberFixture;
 import friendy.community.domain.member.model.Member;
 import friendy.community.domain.post.dto.request.PostCreateRequest;
@@ -8,9 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.time.LocalDate;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,17 +20,16 @@ class PostTest {
 
     @BeforeEach
     void setUp() {
-
         member = MemberFixture.memberFixture();
-
     }
 
     @Test
-    @DisplayName("Post 객체가 생성되는지에 대한 test")
+    @DisplayName("Post 객체가 요청을 기반으로 생성되는지 테스트")
     void ofMethodCreatesPostFromRequest() {
         // Given
         String content = "This is a new post content.";
-        PostCreateRequest postCreateRequest = new PostCreateRequest(content);
+        List<String> hashtags = List.of("프렌디", "개발", "스터디");
+        PostCreateRequest postCreateRequest = new PostCreateRequest(content, hashtags);
 
         // When
         Post post = Post.of(postCreateRequest, member);
@@ -41,6 +38,6 @@ class PostTest {
         assertNotNull(post);
         assertEquals(content, post.getContent());
         assertEquals(member, post.getMember());
-
     }
 }
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #56 

<br/>

## 🔎 작업 내용

- 게시글 생성 시 해시태그 추가
- 게시글 수정 시 해시태그 추가
- 게시글 삭제 시 해시태그 추가

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

> 프론트에서는 게시글 본문에 해시태그를 포함하여 표시하기 때문에, 조회시에는 해시태그를 응답에 포함하지 않아도 될 것 같아 조회에서는 해시태그를 추가하지 않았습니다.